### PR TITLE
Condemn the seer when they reveal themselves

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 A simulation of playing a fairly rational game of werewolf where the villagers simply lynch randomly.  When someone is proposed to be lynched they can reveal their role to avoid lynching but by rational werewolfs should be eaten the next evening.
 
-Other variable is at what point the seer should reveal themselves.  A ~65% win rate can be achieved consistently by the seer revealling themselves on a bunch of fairly basic conditions.
+Other variable is at what point the seer should reveal themselves.  A ~59% win rate can be achieved consistently by the seer revealling themselves on a bunch of fairly basic conditions.
 
 ## Running
 

--- a/game.rb
+++ b/game.rb
@@ -82,8 +82,8 @@ class AnyWerewolf
     return true if werewolf_count == identified_werewolf_count
     return true if villager_count == identified_villager_count
     return true if identified_villager_count + identified_werewolf_count >= (players.count / 2)
-    return true if identified_werewolf_count >= 1
-    return true if identified_villager_count > 3
+    return true if identified_werewolf_count >= 2
+    return true if identified_villager_count > 6
     # seer.identified_werewolfs(players).count >= (players.select(&:werewolf?).count / 4) ||
   end
 end

--- a/game.rb
+++ b/game.rb
@@ -52,6 +52,7 @@ class Seer < Villager
 
     @strategy = strategy
     super()
+    identify!
   end
 
   def role_prevents_lynching?

--- a/spec/information_flow_spec.rb
+++ b/spec/information_flow_spec.rb
@@ -1,0 +1,32 @@
+require 'spec_helper'
+
+require "./game"
+
+
+describe "drawing conclusions from information" do
+  let(:game) {
+    Game.new players
+  }
+
+  describe "when the seer reveals themselves" do
+    let(:players) {
+      [
+        Seer.new(strategy: AnyWerewolf),
+        Villager.new,
+        Werewolf.new
+      ]
+    }
+
+    specify 'they condemn identified players' do
+      players.last.identify!
+      game.seer_reveals!
+
+      expect(players.last).to be_condemned
+    end
+
+    specify 'they condemn themselves' do
+      game.seer_reveals!
+      expect(players.detect(&:seer?)).to be_condemned
+    end
+  end
+end


### PR DESCRIPTION
If the seer revealed themselves voluntarily (due to having found enough werewolves), they weren't getting marked as condemned so the werewolves wouldn't target them.

Fixing this reduces the win rate to 53% (with the strategy in master), or about 59% (after re-optimising the numbers).

That means 4-6% of simulated games change from villager to werewolf wins with this fix. I'm guessing those games had the seer reveal themselves voluntarily (identifying some people), and then later reveal _again_ to avoid getting lynched, identifying more people in the process. With this fix, that would be prevented by the werewolves eating them after the first reveal.
